### PR TITLE
MNT: bump ubuntu image (20.04 -> 22.04)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         python-version: 
           - '3.13'
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             python-version: '3.7'
             pip-args: --constraint constraints/minimal_dependencies.txt
           - os: windows-latest


### PR DESCRIPTION
The ubuntu-20.04 image is deprecated and will soon fail systematically